### PR TITLE
Util.cpp: Fix compilation with GCC6

### DIFF
--- a/imap/src/parser/Util.cpp
+++ b/imap/src/parser/Util.cpp
@@ -45,7 +45,7 @@ static char STANDARD_ALPHABET[] =
     '6', '7', '8', '9', '+', ','
 };
 
-static char UTF7_DECODABET[] =
+static signed char UTF7_DECODABET[] =
     {
         -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
         -5,-5,                                      // Whitespace: Tab and Linefeed


### PR DESCRIPTION
To address issues like:

|
|

error: narrowing conversion of '-9' from 'int' to 'char' inside { }
[-Wnarrowing]

Signed-off-by: Herman van Hazendonk github.com@herrie.org
